### PR TITLE
Added support for dependency binary detection

### DIFF
--- a/server/bin/make
+++ b/server/bin/make
@@ -46,6 +46,9 @@ Dir.mktmpdir do |dir|
     end
 
     unless deps.empty?
+      ENV["PATH"] ||= ""
+      ENV["PATH"] += ":%s/deps/bin" % dir    
+      
       ENV["LDFLAGS"] ||= ""
       ENV["LDFLAGS"] += " -L%s/deps/lib" % dir
 


### PR DESCRIPTION
Some ./configure scripts look in the path for binaries of dependencies. It's a very simple change on top of the dependency support added recently.
