### PR TITLE
Add support pkg-config when using dependencies.

### DIFF
--- a/server/bin/vulcan-make
+++ b/server/bin/vulcan-make
@@ -47,8 +47,11 @@ Dir.mktmpdir do |dir|
 
     unless deps.empty?
       ENV["PATH"] ||= ""
-      ENV["PATH"] += ":%s/deps/bin" % dir    
-      
+      ENV["PATH"] += ":%s/deps/bin" % dir
+
+      ENV["PKG_CONFIG_PATH"] ||= ""
+      ENV["PKG_CONFIG_PATH"] += "%s/deps/lib/pkgconfig" % dir
+
       ENV["LDFLAGS"] ||= ""
       ENV["LDFLAGS"] += " -L%s/deps/lib" % dir
 


### PR DESCRIPTION
Add support for pkg-config. This is necessary to compile packages like poppler.

It's written by @yrb, I tried it myself and it works very well.
