### PR TITLE
`vulcan update` fails

### DIFF
--- a/server/npm-shrinkwrap.json
+++ b/server/npm-shrinkwrap.json
@@ -1,0 +1,70 @@
+{
+  "name": "vulcan",
+  "version": "0.0.1",
+  "dependencies": {
+    "coffee-script": {
+      "version": "1.3.3"
+    },
+    "connect-form": {
+      "version": "0.2.0",
+      "dependencies": {
+        "formidable": {
+          "version": "1.0.9"
+        }
+      }
+    },
+    "cradle": {
+      "version": "0.6.3",
+      "dependencies": {
+        "follow": {
+          "version": "0.7.2",
+          "dependencies": {
+            "request": {
+              "version": "2.2.9"
+            }
+          }
+        },
+        "request": {
+          "version": "2.9.202"
+        },
+        "vargs": {
+          "version": "0.1.0"
+        }
+      }
+    },
+    "express": {
+      "version": "2.5.9",
+      "dependencies": {
+        "connect": {
+          "version": "1.8.7",
+          "dependencies": {
+            "formidable": {
+              "version": "1.0.9"
+            }
+          }
+        },
+        "mime": {
+          "version": "1.2.4"
+        },
+        "qs": {
+          "version": "0.4.2"
+        },
+        "mkdirp": {
+          "version": "0.3.0"
+        }
+      }
+    },
+    "knox": {
+      "version": "0.0.9"
+    },
+    "node-uuid": {
+      "version": "1.3.3"
+    },
+    "nodemon": {
+      "version": "0.6.18"
+    },
+    "restler": {
+      "version": "2.0.1"
+    }
+  }
+}


### PR DESCRIPTION
One of the upstream dependencies (`request`) now requires at least Node 0.8.x:

```
       npm ERR! Not compatible with your version of node/npm: request@2.16.6
       npm ERR! Required: ["node >= 0.8.0"]
       npm ERR! Actual:   {"npm":"1.1.4","node":"0.6.20"}
```
