### PR TITLE
Upgrade multipart-post to version 1.2.0 for support with Ruby 2.0.0

### DIFF
--- a/vulcan.gemspec
+++ b/vulcan.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|server/|spec/|test/)} }
 
   gem.add_dependency "heroku",         ">= 2.26.0", "< 3.0"
-  gem.add_dependency "multipart-post", "~> 1.1.3"
+  gem.add_dependency "multipart-post", "~> 1.2.0"
   gem.add_dependency "rest-client",    "~> 1.6.7"
   gem.add_dependency "thor",           "~> 0.14.6"
 


### PR DESCRIPTION
This hopefully will fix a bug with ruby 2.0 where `vulcan build` does not connect to the server.
